### PR TITLE
Fix padding size calculation

### DIFF
--- a/lib/grad/dashboard.rb
+++ b/lib/grad/dashboard.rb
@@ -47,7 +47,7 @@ LogTo: #{@log_dst}\n\n")
 
     # print memory stats
     mem_u = @watcher_obj.memory[:units]
-    if @watcher_obj.memory[:m_total] >= @watcher_obj.memory[:s_total] 
+    if @watcher_obj.memory[:m_total].to_i >= @watcher_obj.memory[:s_total].to_i
       l = @watcher_obj.memory[:m_total].to_s.length 
     else 
       l = @watcher_obj.memory[:s_total].to_s.length


### PR DESCRIPTION
Both memory records (regular, swap) were interpreted as strings, so a
lexicographic comparision was made.

Force the comparison between their integral representations.